### PR TITLE
fix: use standard .js files for module

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.1",
   "description": "Positioning library for floating elements: tooltips, popovers, dropdowns, and more",
   "main": "dist/floating-ui.core.js",
-  "module": "dist/floating-ui.core.js",
+  "module": "dist/floating-ui.core.esm.js",
   "unpkg": "dist/floating-ui.core.min.js",
   "sideEffects": false,
   "files": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.1",
   "description": "Positioning library for floating elements: tooltips, popovers, dropdowns, and more",
   "main": "dist/floating-ui.core.js",
-  "module": "dist/floating-ui.core.mjs",
+  "module": "dist/floating-ui.core.js",
   "unpkg": "dist/floating-ui.core.min.js",
   "sideEffects": false,
   "files": [

--- a/packages/core/rollup.config.js
+++ b/packages/core/rollup.config.js
@@ -11,14 +11,14 @@ const bundles = [
   {
     input,
     output: {
-      file: path.join(__dirname, 'dist/floating-ui.core.js'),
+      file: path.join(__dirname, 'dist/floating-ui.core.esm.js'),
       format: 'esm',
     },
   },
   {
     input,
     output: {
-      file: path.join(__dirname, 'dist/floating-ui.core.min.js'),
+      file: path.join(__dirname, 'dist/floating-ui.core.esm.min.js'),
       format: 'esm',
     },
   },
@@ -60,7 +60,7 @@ const buildExport = bundles.map(({input, output}) => ({
 const devExport = {
   input: path.join(__dirname, 'src/index.ts'),
   output: {
-    file: path.join(__dirname, `dist/floating-ui.core.js`),
+    file: path.join(__dirname, `dist/floating-ui.core.esm.js`),
     format: 'esm',
   },
   plugins: [

--- a/packages/core/rollup.config.js
+++ b/packages/core/rollup.config.js
@@ -11,14 +11,14 @@ const bundles = [
   {
     input,
     output: {
-      file: path.join(__dirname, 'dist/floating-ui.core.mjs'),
+      file: path.join(__dirname, 'dist/floating-ui.core.js'),
       format: 'esm',
     },
   },
   {
     input,
     output: {
-      file: path.join(__dirname, 'dist/floating-ui.core.min.mjs'),
+      file: path.join(__dirname, 'dist/floating-ui.core.min.js'),
       format: 'esm',
     },
   },
@@ -60,7 +60,7 @@ const buildExport = bundles.map(({input, output}) => ({
 const devExport = {
   input: path.join(__dirname, 'src/index.ts'),
   output: {
-    file: path.join(__dirname, `dist/floating-ui.core.mjs`),
+    file: path.join(__dirname, `dist/floating-ui.core.js`),
     format: 'esm',
   },
   plugins: [

--- a/packages/dom/package.json
+++ b/packages/dom/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.1",
   "description": "Floating UI for the web",
   "main": "dist/floating-ui.dom.js",
-  "module": "dist/floating-ui.dom.mjs",
+  "module": "dist/floating-ui.dom.js",
   "unpkg": "dist/floating-ui.dom.min.js",
   "sideEffects": false,
   "files": [

--- a/packages/dom/package.json
+++ b/packages/dom/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.1",
   "description": "Floating UI for the web",
   "main": "dist/floating-ui.dom.js",
-  "module": "dist/floating-ui.dom.js",
+  "module": "dist/floating-ui.dom.esm.js",
   "unpkg": "dist/floating-ui.dom.min.js",
   "sideEffects": false,
   "files": [

--- a/packages/dom/rollup.config.js
+++ b/packages/dom/rollup.config.js
@@ -10,14 +10,14 @@ const bundles = [
   {
     input,
     output: {
-      file: path.join(__dirname, 'dist/floating-ui.dom.js'),
+      file: path.join(__dirname, 'dist/floating-ui.dom.esm.js'),
       format: 'esm',
     },
   },
   {
     input,
     output: {
-      file: path.join(__dirname, 'dist/floating-ui.dom.min.js'),
+      file: path.join(__dirname, 'dist/floating-ui.dom.esm.min.js'),
       format: 'esm',
     },
   },

--- a/packages/dom/rollup.config.js
+++ b/packages/dom/rollup.config.js
@@ -10,14 +10,14 @@ const bundles = [
   {
     input,
     output: {
-      file: path.join(__dirname, 'dist/floating-ui.dom.mjs'),
+      file: path.join(__dirname, 'dist/floating-ui.dom.js'),
       format: 'esm',
     },
   },
   {
     input,
     output: {
-      file: path.join(__dirname, 'dist/floating-ui.dom.min.mjs'),
+      file: path.join(__dirname, 'dist/floating-ui.dom.min.js'),
       format: 'esm',
     },
   },
@@ -65,7 +65,7 @@ const buildExport = bundles.map(({input, output}) => ({
 const devExport = {
   input: path.join(__dirname, 'src/index.ts'),
   output: {
-    file: path.join(__dirname, `test/visual/dist/index.mjs`),
+    file: path.join(__dirname, `test/visual/dist/index.js`),
     format: 'esm',
   },
   plugins: [

--- a/packages/react-dom/package.json
+++ b/packages/react-dom/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.2",
   "description": "Floating UI for React DOM",
   "main": "dist/floating-ui.react-dom.js",
-  "module": "dist/floating-ui.react-dom.mjs",
+  "module": "dist/floating-ui.react-dom.js",
   "unpkg": "dist/floating-ui.react-dom.min.js",
   "sideEffects": false,
   "files": [

--- a/packages/react-dom/package.json
+++ b/packages/react-dom/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.2",
   "description": "Floating UI for React DOM",
   "main": "dist/floating-ui.react-dom.js",
-  "module": "dist/floating-ui.react-dom.js",
+  "module": "dist/floating-ui.react-dom.esm.js",
   "unpkg": "dist/floating-ui.react-dom.min.js",
   "sideEffects": false,
   "files": [

--- a/packages/react-dom/rollup.config.js
+++ b/packages/react-dom/rollup.config.js
@@ -11,14 +11,14 @@ const bundles = [
   {
     input,
     output: {
-      file: path.join(__dirname, 'dist/floating-ui.react-dom.mjs'),
+      file: path.join(__dirname, 'dist/floating-ui.react-dom.js'),
       format: 'esm',
     },
   },
   {
     input,
     output: {
-      file: path.join(__dirname, 'dist/floating-ui.react-dom.min.mjs'),
+      file: path.join(__dirname, 'dist/floating-ui.react-dom.min.js'),
       format: 'esm',
     },
   },
@@ -73,7 +73,7 @@ const buildExport = bundles.map(({input, output}) => ({
 const devExport = {
   input: path.join(__dirname, 'src/index.ts'),
   output: {
-    file: path.join(__dirname, `test/visual/dist/index.mjs`),
+    file: path.join(__dirname, `test/visual/dist/index.js`),
     format: 'esm',
   },
   plugins: [

--- a/packages/react-dom/rollup.config.js
+++ b/packages/react-dom/rollup.config.js
@@ -11,14 +11,14 @@ const bundles = [
   {
     input,
     output: {
-      file: path.join(__dirname, 'dist/floating-ui.react-dom.js'),
+      file: path.join(__dirname, 'dist/floating-ui.react-dom.esm.js'),
       format: 'esm',
     },
   },
   {
     input,
     output: {
-      file: path.join(__dirname, 'dist/floating-ui.react-dom.min.js'),
+      file: path.join(__dirname, 'dist/floating-ui.react-dom.esm.min.js'),
       format: 'esm',
     },
   },

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.1",
   "description": "Floating UI for React Native",
   "main": "dist/floating-ui.react-native.js",
-  "module": "dist/floating-ui.react-native.mjs",
+  "module": "dist/floating-ui.react-native.js",
   "sideEffects": false,
   "files": [
     "dist/",

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.1",
   "description": "Floating UI for React Native",
   "main": "dist/floating-ui.react-native.js",
-  "module": "dist/floating-ui.react-native.js",
+  "module": "dist/floating-ui.react-native.esm.js",
   "sideEffects": false,
   "files": [
     "dist/",

--- a/packages/react-native/rollup.config.js
+++ b/packages/react-native/rollup.config.js
@@ -11,14 +11,14 @@ const bundles = [
   {
     input,
     output: {
-      file: path.join(__dirname, 'dist/floating-ui.react-native.js'),
+      file: path.join(__dirname, 'dist/floating-ui.react-native.esm.js'),
       format: 'esm',
     },
   },
   {
     input,
     output: {
-      file: path.join(__dirname, 'dist/floating-ui.react-native.min.js'),
+      file: path.join(__dirname, 'dist/floating-ui.react-native.esm.min.js'),
       format: 'esm',
     },
   },

--- a/packages/react-native/rollup.config.js
+++ b/packages/react-native/rollup.config.js
@@ -11,14 +11,14 @@ const bundles = [
   {
     input,
     output: {
-      file: path.join(__dirname, 'dist/floating-ui.react-native.mjs'),
+      file: path.join(__dirname, 'dist/floating-ui.react-native.js'),
       format: 'esm',
     },
   },
   {
     input,
     output: {
-      file: path.join(__dirname, 'dist/floating-ui.react-native.min.mjs'),
+      file: path.join(__dirname, 'dist/floating-ui.react-native.min.js'),
       format: 'esm',
     },
   },


### PR DESCRIPTION
`.mjs` has a lot of interop issues with webpack bundlers, so I'm gonna make these standard `.js` files for now.

Nuxt 3 requires `.mjs` files so I'm not sure the best way to handle this, but this will support the majority of users, for now. 

Fixes #2 