### PR TITLE
chore: add repository field to package.json files

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,6 +20,11 @@
   "author": "atomiks",
   "license": "MIT",
   "bugs": "https://github.com/atomiks/floating-ui",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/atomiks/floating-ui.git",
+    "directory": "packages/core"
+  },
   "homepage": "https://floating-ui.com",
   "keywords": [
     "tooltip",

--- a/packages/dom/package.json
+++ b/packages/dom/package.json
@@ -22,6 +22,11 @@
   "author": "atomiks",
   "license": "MIT",
   "bugs": "https://github.com/atomiks/floating-ui",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/atomiks/floating-ui.git",
+    "directory": "packages/dom"
+  },
   "homepage": "https://floating-ui.com",
   "keywords": [
     "tooltip",

--- a/packages/react-dom/package.json
+++ b/packages/react-dom/package.json
@@ -20,6 +20,11 @@
   "author": "atomiks",
   "license": "MIT",
   "bugs": "https://github.com/atomiks/floating-ui",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/atomiks/floating-ui.git",
+    "directory": "packages/react-dom"
+  },
   "homepage": "https://floating-ui.com/docs/react-dom",
   "keywords": [
     "tooltip",

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -18,6 +18,11 @@
   "author": "atomiks",
   "license": "MIT",
   "bugs": "https://github.com/atomiks/floating-ui",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/atomiks/floating-ui.git",
+    "directory": "packages/react-native"
+  },
   "homepage": "https://floating-ui.com/docs/react-native",
   "keywords": [
     "tooltip",


### PR DESCRIPTION
To display the repository field in the npmjs.com registry.

Docs: https://docs.npmjs.com/cli/v8/configuring-npm/package-json#repository
