### PR TITLE
feat: memoize `middleware` internally in `react-dom` and `react-native`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6180,6 +6180,42 @@
         "tailwindcss": ">=2.0.0"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "8.11.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.11.1.tgz",
+      "integrity": "sha512-3KQDyx9r0RKYailW2MiYrSSKEfH0GTkI51UGEvJenvcoDoeRYs0PZpi2SXqtnMClQvCqdtTTpOfFETDTVADpAg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^4.2.0",
+        "aria-query": "^5.0.0",
+        "chalk": "^4.1.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.4.4",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "12.1.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-12.1.2.tgz",
+      "integrity": "sha512-ihQiEOklNyHIpo2Y8FREkyD1QAea054U0MVbwH1m8N9TxeFz+KoJ9LkqoKqJlzx2JDm56DVwaJ1r36JYxZM05g==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@testing-library/dom": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
+      }
+    },
     "node_modules/@testing-library/react-hooks": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/@testing-library/react-hooks/-/react-hooks-7.0.2.tgz",
@@ -6237,6 +6273,12 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.2.tgz",
+      "integrity": "sha512-HnYpAE1Y6kRyKM/XkEuiRQhTHvkzMBurTHnpFLYLBGPIylZNPs9jJcuOOYWxPLJCSEtmZT0Y8rHDokKN7rRTig==",
+      "dev": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.1.16",
@@ -7240,6 +7282,15 @@
       "license": "MIT",
       "dependencies": {
         "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.0.0.tgz",
+      "integrity": "sha512-V+SM7AbUwJ+EBnB8+DXs0hPZHO0W6pqBcc0dW90OwtVG02PswOu/teuARoLQjdDOH+t9pJgGnW5/Qmouf3gPJg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0"
       }
     },
     "node_modules/arr-diff": {
@@ -10019,6 +10070,12 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.10.tgz",
+      "integrity": "sha512-Xu9mD0UjrJisTmv7lmVSDMagQcU9R5hwAbxsaAE/35XPnPLJobbuREfV/rraiSaEj/UOvgrzQs66zyTWTlyd+g==",
+      "dev": true
     },
     "node_modules/dom-serializer": {
       "version": "1.3.2",
@@ -14659,6 +14716,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
+      "integrity": "sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=",
+      "dev": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
       }
     },
     "node_modules/magic-string": {
@@ -24030,7 +24096,7 @@
     },
     "packages/core": {
       "name": "@floating-ui/core",
-      "version": "0.1.0",
+      "version": "0.1.2",
       "license": "MIT",
       "devDependencies": {
         "@atomico/rollup-plugin-sizes": "^1.1.4",
@@ -24049,10 +24115,10 @@
     },
     "packages/dom": {
       "name": "@floating-ui/dom",
-      "version": "0.1.0",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/core": "^0.1.0"
+        "@floating-ui/core": "^0.1.2"
       },
       "devDependencies": {
         "@babel/preset-env": "^7.16.4",
@@ -24092,19 +24158,21 @@
     },
     "packages/react-dom": {
       "name": "@floating-ui/react-dom",
-      "version": "0.1.0",
+      "version": "0.1.3",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/dom": "^0.1.0",
+        "@floating-ui/dom": "^0.1.2",
         "use-isomorphic-layout-effect": "^1.1.1"
       },
       "devDependencies": {
         "@babel/preset-env": "^7.16.4",
+        "@babel/preset-react": "^7.16.0",
         "@babel/preset-typescript": "^7.16.0",
         "@rollup/plugin-babel": "^5.3.0",
         "@rollup/plugin-commonjs": "^21.0.1",
         "@rollup/plugin-node-resolve": "^13.0.6",
         "@rollup/plugin-replace": "^3.0.0",
+        "@testing-library/react": "^12.1.2",
         "@testing-library/react-hooks": "^7.0.2",
         "@types/jest": "^27.0.3",
         "@types/react": "^17.0.37",
@@ -24124,10 +24192,10 @@
     },
     "packages/react-native": {
       "name": "@floating-ui/react-native",
-      "version": "0.1.0",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/core": "^0.1.0"
+        "@floating-ui/core": "^0.1.2"
       },
       "devDependencies": {
         "@babel/preset-env": "^7.16.4",
@@ -25527,7 +25595,7 @@
       "requires": {
         "@babel/preset-env": "^7.16.4",
         "@babel/preset-typescript": "^7.16.0",
-        "@floating-ui/core": "^0.1.0",
+        "@floating-ui/core": "^0.1.2",
         "@playwright/test": "^1.16.3",
         "@rollup/plugin-replace": "^3.0.0",
         "@types/jest": "^27.0.3",
@@ -25543,12 +25611,14 @@
       "version": "file:packages/react-dom",
       "requires": {
         "@babel/preset-env": "^7.16.4",
+        "@babel/preset-react": "*",
         "@babel/preset-typescript": "^7.16.0",
-        "@floating-ui/dom": "^0.1.0",
+        "@floating-ui/dom": "^0.1.2",
         "@rollup/plugin-babel": "^5.3.0",
         "@rollup/plugin-commonjs": "^21.0.1",
         "@rollup/plugin-node-resolve": "^13.0.6",
         "@rollup/plugin-replace": "^3.0.0",
+        "@testing-library/react": "^12.1.2",
         "@testing-library/react-hooks": "^7.0.2",
         "@types/jest": "^27.0.3",
         "@types/react": "^17.0.37",
@@ -25560,7 +25630,7 @@
         "rollup-plugin-terser": "^7.0.2",
         "ts-jest": "^27.0.7",
         "typescript": "^4.5.2",
-        "use-isomorphic-layout-effect": "*"
+        "use-isomorphic-layout-effect": "^1.1.1"
       }
     },
     "@floating-ui/react-native": {
@@ -25568,7 +25638,7 @@
       "requires": {
         "@babel/preset-env": "^7.16.4",
         "@babel/preset-typescript": "^7.16.0",
-        "@floating-ui/core": "^0.1.0",
+        "@floating-ui/core": "^0.1.2",
         "@rollup/plugin-babel": "^5.3.0",
         "@rollup/plugin-commonjs": "^21.0.1",
         "@rollup/plugin-node-resolve": "^13.0.6",
@@ -28589,6 +28659,32 @@
         "lodash.uniq": "^4.5.0"
       }
     },
+    "@testing-library/dom": {
+      "version": "8.11.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.11.1.tgz",
+      "integrity": "sha512-3KQDyx9r0RKYailW2MiYrSSKEfH0GTkI51UGEvJenvcoDoeRYs0PZpi2SXqtnMClQvCqdtTTpOfFETDTVADpAg==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^4.2.0",
+        "aria-query": "^5.0.0",
+        "chalk": "^4.1.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.4.4",
+        "pretty-format": "^27.0.2"
+      }
+    },
+    "@testing-library/react": {
+      "version": "12.1.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-12.1.2.tgz",
+      "integrity": "sha512-ihQiEOklNyHIpo2Y8FREkyD1QAea054U0MVbwH1m8N9TxeFz+KoJ9LkqoKqJlzx2JDm56DVwaJ1r36JYxZM05g==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "@testing-library/dom": "^8.0.0"
+      }
+    },
     "@testing-library/react-hooks": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/@testing-library/react-hooks/-/react-hooks-7.0.2.tgz",
@@ -28618,6 +28714,12 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz",
       "integrity": "sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==",
+      "dev": true
+    },
+    "@types/aria-query": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.2.tgz",
+      "integrity": "sha512-HnYpAE1Y6kRyKM/XkEuiRQhTHvkzMBurTHnpFLYLBGPIylZNPs9jJcuOOYWxPLJCSEtmZT0Y8rHDokKN7rRTig==",
       "dev": true
     },
     "@types/babel__core": {
@@ -29425,6 +29527,12 @@
       "requires": {
         "sprintf-js": "~1.0.2"
       }
+    },
+    "aria-query": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.0.0.tgz",
+      "integrity": "sha512-V+SM7AbUwJ+EBnB8+DXs0hPZHO0W6pqBcc0dW90OwtVG02PswOu/teuARoLQjdDOH+t9pJgGnW5/Qmouf3gPJg==",
+      "dev": true
     },
     "arr-diff": {
       "version": "4.0.0",
@@ -31573,6 +31681,12 @@
       "requires": {
         "esutils": "^2.0.2"
       }
+    },
+    "dom-accessibility-api": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.10.tgz",
+      "integrity": "sha512-Xu9mD0UjrJisTmv7lmVSDMagQcU9R5hwAbxsaAE/35XPnPLJobbuREfV/rraiSaEj/UOvgrzQs66zyTWTlyd+g==",
+      "dev": true
     },
     "dom-serializer": {
       "version": "1.3.2",
@@ -35010,6 +35124,12 @@
       "requires": {
         "yallist": "^4.0.0"
       }
+    },
+    "lz-string": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
+      "integrity": "sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=",
+      "dev": true
     },
     "magic-string": {
       "version": "0.25.7",

--- a/packages/react-dom/babel.config.js
+++ b/packages/react-dom/babel.config.js
@@ -1,3 +1,3 @@
 module.exports = {
-  presets: [['@babel/env', {loose: true}], '@babel/typescript'],
+  presets: [['@babel/env', {loose: true}], '@babel/typescript', '@babel/react'],
 };

--- a/packages/react-dom/jest.config.js
+++ b/packages/react-dom/jest.config.js
@@ -1,7 +1,7 @@
 /** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
 module.exports = {
   preset: 'ts-jest',
-  testEnvironment: 'node',
+  testEnvironment: 'jsdom',
   globals: {
     __DEV__: true,
   },

--- a/packages/react-dom/package.json
+++ b/packages/react-dom/package.json
@@ -13,6 +13,7 @@
   ],
   "browserslist": "> 0.5%, not dead, not IE 11",
   "scripts": {
+    "test2": "node --inspect-brk ../../node_modules/.bin/jest test",
     "test": "jest test",
     "build": "NODE_ENV=build rollup -c",
     "dev": "parcel test/visual/index.html --dist-dir test/visual/dist"
@@ -41,11 +42,13 @@
   },
   "devDependencies": {
     "@babel/preset-env": "^7.16.4",
+    "@babel/preset-react": "^7.16.0",
     "@babel/preset-typescript": "^7.16.0",
     "@rollup/plugin-babel": "^5.3.0",
     "@rollup/plugin-commonjs": "^21.0.1",
     "@rollup/plugin-node-resolve": "^13.0.6",
     "@rollup/plugin-replace": "^3.0.0",
+    "@testing-library/react": "^12.1.2",
     "@testing-library/react-hooks": "^7.0.2",
     "@types/jest": "^27.0.3",
     "@types/react": "^17.0.37",

--- a/packages/react-dom/package.json
+++ b/packages/react-dom/package.json
@@ -13,7 +13,6 @@
   ],
   "browserslist": "> 0.5%, not dead, not IE 11",
   "scripts": {
-    "test2": "node --inspect-brk ../../node_modules/.bin/jest test",
     "test": "jest test",
     "build": "NODE_ENV=build rollup -c",
     "dev": "parcel test/visual/index.html --dist-dir test/visual/dist"

--- a/packages/react-dom/src/index.ts
+++ b/packages/react-dom/src/index.ts
@@ -67,7 +67,7 @@ export function useFloating({
     }).then(setData);
   }, [latestMiddleware, placement, strategy]);
 
-  useIsomorphicLayoutEffect(update, [latestMiddleware, placement, strategy]);
+  useIsomorphicLayoutEffect(update, [update]);
 
   const setReference = useCallback(
     (node) => {

--- a/packages/react-dom/src/index.ts
+++ b/packages/react-dom/src/index.ts
@@ -5,6 +5,7 @@ import type {
 import {computePosition} from '@floating-ui/dom';
 import {useCallback, useMemo, useState, useRef, MutableRefObject} from 'react';
 import useIsomorphicLayoutEffect from 'use-isomorphic-layout-effect';
+import {useLatestRef} from './utils/useLatestRef';
 
 export {
   arrow,
@@ -51,10 +52,8 @@ export function useFloating({
     middlewareData: {},
   });
 
-  const latestMiddleware = useRef(middleware);
-  useIsomorphicLayoutEffect(() => {
-    latestMiddleware.current = middleware;
-  });
+  // Memoize middleware internally, to remove the requirement of memoization by consumer
+  const latestMiddleware = useLatestRef(middleware);
 
   const update = useCallback(() => {
     if (!reference.current || !floating.current) {
@@ -66,9 +65,9 @@ export function useFloating({
       placement,
       strategy,
     }).then(setData);
-  }, [placement, strategy]);
+  }, [latestMiddleware, placement, strategy]);
 
-  useIsomorphicLayoutEffect(update, [placement, strategy]);
+  useIsomorphicLayoutEffect(update, [latestMiddleware, placement, strategy]);
 
   const setReference = useCallback(
     (node) => {

--- a/packages/react-dom/src/utils/useLatestRef.ts
+++ b/packages/react-dom/src/utils/useLatestRef.ts
@@ -1,0 +1,15 @@
+import {useRef} from 'react';
+import useIsomorphicLayoutEffect from 'use-isomorphic-layout-effect';
+
+/**
+ * @see https://epicreact.dev/the-latest-ref-pattern-in-react/
+ */
+export function useLatestRef<Value>(value: Value) {
+  const ref = useRef(value);
+
+  useIsomorphicLayoutEffect(() => {
+    ref.current = value;
+  });
+
+  return ref;
+}

--- a/packages/react-dom/test/index.test.tsx
+++ b/packages/react-dom/test/index.test.tsx
@@ -3,10 +3,48 @@
  */
 import {useFloating} from '../src';
 import {renderHook} from '@testing-library/react-hooks';
+import {render, waitFor} from '@testing-library/react';
+import * as FloatingUIDom from '@floating-ui/dom';
 
 test('`x` and `y` are initially `null`', async () => {
   const {result} = renderHook(() => useFloating());
 
   expect(result.current.x).toBe(null);
   expect(result.current.y).toBe(null);
+});
+
+test('`middleware` is memoized internally', async () => {
+  function Component() {
+    const {reference, floating} = useFloating({
+      middleware: [
+        {
+          name: 'identity',
+          fn({x, y}) {
+            return {x, y};
+          },
+        },
+      ],
+    });
+
+    return (
+      <div>
+        <button ref={reference}>button</button>
+        <div ref={floating}>floating</div>
+      </div>
+    );
+  }
+
+  const spy = jest.spyOn(FloatingUIDom, 'computePosition');
+
+  const {rerender} = render(<Component />);
+
+  await waitFor(() => {
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
+
+  rerender(<Component />);
+
+  await waitFor(() => {
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
 });

--- a/packages/react-native/src/utils/useLatestRef.ts
+++ b/packages/react-native/src/utils/useLatestRef.ts
@@ -1,0 +1,15 @@
+import {useRef} from 'react';
+import useIsomorphicLayoutEffect from 'use-isomorphic-layout-effect';
+
+/**
+ * @see https://epicreact.dev/the-latest-ref-pattern-in-react/
+ */
+export function useLatestRef<Value>(value: Value) {
+  const ref = useRef(value);
+
+  useIsomorphicLayoutEffect(() => {
+    ref.current = value;
+  });
+
+  return ref;
+}

--- a/packages/react-native/src/utils/useLatestRef.ts
+++ b/packages/react-native/src/utils/useLatestRef.ts
@@ -1,5 +1,4 @@
-import {useRef} from 'react';
-import useIsomorphicLayoutEffect from 'use-isomorphic-layout-effect';
+import {useLayoutEffect, useRef} from 'react';
 
 /**
  * @see https://epicreact.dev/the-latest-ref-pattern-in-react/
@@ -7,7 +6,7 @@ import useIsomorphicLayoutEffect from 'use-isomorphic-layout-effect';
 export function useLatestRef<Value>(value: Value) {
   const ref = useRef(value);
 
-  useIsomorphicLayoutEffect(() => {
+  useLayoutEffect(() => {
     ref.current = value;
   });
 

--- a/website/pages/docs/react-dom.mdx
+++ b/website/pages/docs/react-dom.mdx
@@ -16,17 +16,13 @@ yarn add @floating-ui/react-dom
 The `useFloating()` hook accepts all of
 [computePosition's options](/docs/computePosition#options).
 
-Middleware must be either memo'd or declared outside of the
-function body to prevent an infinite render loop.
-
 ```jsx
-import {useMemo} from 'react';
 import {useFloating, shift} from '@floating-ui/react-dom';
 
 function App() {
   const {x, y, reference, floating, strategy} = useFloating({
     placement: 'right',
-    middleware: useMemo(() => [shift()], []),
+    middleware: [shift()],
   });
 
   return (
@@ -78,7 +74,7 @@ For instance, to update on all relevant nodes, you can import the
 `getScrollParents` util from the package:
 
 ```jsx {5,9,15-37}
-import {useMemo, useEffect} from 'react';
+import {useEffect} from 'react';
 import {
   useFloating,
   shift,
@@ -89,7 +85,7 @@ function App() {
   const {x, y, reference, floating, strategy, update, refs} =
     useFloating({
       placement: 'right',
-      middleware: useMemo(() => [shift()], []),
+      middleware: [shift()],
     });
 
   // Update on scroll and resize for all relevant nodes
@@ -149,13 +145,13 @@ const {middlewareData} = useFloating();
 See [Virtual Elements](/docs/virtual-elements) for details.
 
 ```jsx
-import {useMemo, useLayoutEffect} from 'react';
+import {useLayoutEffect} from 'react';
 import {useFloating, shift} from '@floating-ui/react-dom';
 
 function App() {
   const {x, y, reference, floating, strategy} = useFloating({
     placement: 'right',
-    middleware: useMemo(() => [shift()], []),
+    middleware: [shift()],
   });
 
   useLayoutEffect(() => {

--- a/website/pages/docs/react-dom.mdx
+++ b/website/pages/docs/react-dom.mdx
@@ -16,13 +16,17 @@ yarn add @floating-ui/react-dom
 The `useFloating()` hook accepts all of
 [computePosition's options](/docs/computePosition#options).
 
+Middleware must be either memo'd or declared outside of the
+function body to prevent an infinite render loop.
+
 ```jsx
+import {useMemo} from 'react';
 import {useFloating, shift} from '@floating-ui/react-dom';
 
 function App() {
   const {x, y, reference, floating, strategy} = useFloating({
     placement: 'right',
-    middleware: [shift()],
+    middleware: useMemo(() => [shift()], []),
   });
 
   return (
@@ -74,7 +78,7 @@ For instance, to update on all relevant nodes, you can import the
 `getScrollParents` util from the package:
 
 ```jsx {5,9,15-37}
-import {useEffect} from 'react';
+import {useMemo, useEffect} from 'react';
 import {
   useFloating,
   shift,
@@ -85,7 +89,7 @@ function App() {
   const {x, y, reference, floating, strategy, update, refs} =
     useFloating({
       placement: 'right',
-      middleware: [shift()],
+      middleware: useMemo(() => [shift()], []),
     });
 
   // Update on scroll and resize for all relevant nodes
@@ -145,13 +149,13 @@ const {middlewareData} = useFloating();
 See [Virtual Elements](/docs/virtual-elements) for details.
 
 ```jsx
-import {useLayoutEffect} from 'react';
+import {useMemo, useLayoutEffect} from 'react';
 import {useFloating, shift} from '@floating-ui/react-dom';
 
 function App() {
   const {x, y, reference, floating, strategy} = useFloating({
     placement: 'right',
-    middleware: [shift()],
+    middleware: useMemo(() => [shift()], []),
   });
 
   useLayoutEffect(() => {


### PR DESCRIPTION
It uses [Latest Ref Pattern](https://epicreact.dev/the-latest-ref-pattern-in-react/) to memoize `middlewares` array, so that users don't have to use `useMemo` themselves.

Affects `react-dom` and `react-native` packages.

- [x] add working test
- [x] ~~update docs~~
- [x] clean up code

