### PR TITLE
docs: memoize `middleware` internally in `react-dom` and `react-native`

### DIFF
--- a/packages/react-dom/test/visual/index.js
+++ b/packages/react-dom/test/visual/index.js
@@ -1,11 +1,11 @@
-import {useEffect, useMemo} from 'react';
+import {useEffect} from 'react';
 import {render} from 'react-dom';
 import {useFloating, shift, flip, getScrollParents} from '../../src';
 
 function App() {
   const {x, y, reference, floating, update} = useFloating({
     placement: 'top-end',
-    middleware: useMemo(() => [flip(), shift()], []),
+    middleware: [flip(), shift()],
   });
 
   useEffect(() => {

--- a/website/components/Floating.js
+++ b/website/components/Floating.js
@@ -1,4 +1,4 @@
-import {cloneElement, useEffect, useMemo, useState} from 'react';
+import {cloneElement, useEffect, useState} from 'react';
 import {createPortal} from 'react-dom';
 import * as FloatingUI from '../../packages/react-dom';
 import {getScrollParents} from '../../packages/dom';
@@ -25,27 +25,24 @@ export function Floating({
     middlewareData,
     refs,
   } = FloatingUI.useFloating({
-    middleware: useMemo(
-      () =>
-        middleware
-          ?.map(({name, options}) =>
-            name !== 'size'
-              ? FloatingUI[name]?.(options)
-              : FloatingUI.size?.({
-                  ...options,
-                  apply: ({width, height}) => {
-                    setDimensions({
-                      width,
-                      height: minHeight
-                        ? Math.max(height, minHeight)
-                        : height,
-                    });
-                  },
-                })
-          )
-          .filter((v) => v) ?? [],
-      [middleware, minHeight]
-    ),
+    middleware:
+      middleware
+        ?.map(({name, options}) =>
+          name !== 'size'
+            ? FloatingUI[name]?.(options)
+            : FloatingUI.size?.({
+                ...options,
+                apply: ({width, height}) => {
+                  setDimensions({
+                    width,
+                    height: minHeight
+                      ? Math.max(height, minHeight)
+                      : height,
+                  });
+                },
+              })
+        )
+        .filter((v) => v) ?? [],
     ...options,
   });
 

--- a/website/pages/docs/react-dom.mdx
+++ b/website/pages/docs/react-dom.mdx
@@ -16,17 +16,13 @@ yarn add @floating-ui/react-dom
 The `useFloating()` hook accepts all of
 [computePosition's options](/docs/computePosition#options).
 
-Middleware must be either memo'd or declared outside of the
-function body to prevent an infinite render loop.
-
 ```jsx
-import {useMemo} from 'react';
 import {useFloating, shift} from '@floating-ui/react-dom';
 
 function App() {
   const {x, y, reference, floating, strategy} = useFloating({
     placement: 'right',
-    middleware: useMemo(() => [shift()], []),
+    middleware: [shift()],
   });
 
   return (
@@ -78,7 +74,7 @@ For instance, to update on all relevant nodes, you can import the
 `getScrollParents` util from the package:
 
 ```jsx {5,9,15-37}
-import {useMemo, useEffect} from 'react';
+import {useEffect} from 'react';
 import {
   useFloating,
   shift,
@@ -89,7 +85,7 @@ function App() {
   const {x, y, reference, floating, strategy, update, refs} =
     useFloating({
       placement: 'right',
-      middleware: useMemo(() => [shift()], []),
+      middleware: [shift()],
     });
 
   // Update on scroll and resize for all relevant nodes
@@ -149,13 +145,13 @@ const {middlewareData} = useFloating();
 See [Virtual Elements](/docs/virtual-elements) for details.
 
 ```jsx
-import {useMemo, useLayoutEffect} from 'react';
+import {useLayoutEffect} from 'react';
 import {useFloating, shift} from '@floating-ui/react-dom';
 
 function App() {
   const {x, y, reference, floating, strategy} = useFloating({
     placement: 'right',
-    middleware: useMemo(() => [shift()], []),
+    middleware: [shift()],
   });
 
   useLayoutEffect(() => {

--- a/website/pages/docs/react-native.mdx
+++ b/website/pages/docs/react-native.mdx
@@ -26,18 +26,14 @@ yarn add @floating-ui/react-native
 The `useFloating()` hook accepts all of
 [computePosition's options](/docs/computePosition#options).
 
-Middleware must be either memo'd or declared outside of the
-function body to prevent an infinite render loop.
-
 ```jsx
-import {useMemo} from 'react';
 import {View, Text} from 'react-native';
 import {useFloating, shift} from '@floating-ui/react-native';
 
 function App() {
   const {x, y, reference, floating} = useFloating({
     placement: 'right',
-    middleware: useMemo(() => [shift()], []),
+    middleware: [shift()],
   });
 
   return (


### PR DESCRIPTION
Documentation for #9 

Removes redundant usage of `useMemo` from code examples in `react-dom` and `react-native` docs.
Removes `useMemo` from website components.