### PR TITLE
fix: limitShift type

### DIFF
--- a/packages/core/src/middleware/shift.ts
+++ b/packages/core/src/middleware/shift.ts
@@ -81,8 +81,8 @@ export type LimitShiftOptions = {
 export const limitShift =
   (
     options: Partial<LimitShiftOptions> = {}
-  ): ((middlewareArguments: MiddlewareArguments) => void) =>
-  async (middlewareArguments: MiddlewareArguments) => {
+  ): ((middlewareArguments: MiddlewareArguments) => Coords) =>
+  (middlewareArguments: MiddlewareArguments) => {
     const {x, y, placement, rects, middlewareData} = middlewareArguments;
     const {
       offset = 0,
@@ -148,5 +148,5 @@ export const limitShift =
     return {
       [mainAxis]: mainAxisCoord,
       [crossAxis]: crossAxisCoord,
-    };
+    } as Coords;
   };


### PR DESCRIPTION
Thanks for the wonderful work 🎉 

Using 
```ts
import {shift, limitShift} from '@floating-ui/dom';

shift({limiter: limitShift()});
```

will produce a TypeScript error because limitShift returns an async function with a void return type.