### PR TITLE
feat: wrap arrow middleware to allow ref in React

### DIFF
--- a/packages/react-dom/src/index.ts
+++ b/packages/react-dom/src/index.ts
@@ -103,8 +103,8 @@ export const arrow = ({
   element,
   padding,
 }: {
-  element: MutableRefObject<HTMLElement | null> | HTMLElement;
-  padding: number | SideObject;
+  element: MutableRefObject<HTMLElement | undefined> | HTMLElement;
+  padding?: number | SideObject;
 }): Middleware => {
   function isRef(value: unknown): value is MutableRefObject<unknown> {
     return Object.prototype.hasOwnProperty.call(value, 'current');

--- a/packages/react-dom/src/index.ts
+++ b/packages/react-dom/src/index.ts
@@ -117,7 +117,7 @@ export const arrow = ({
         return arrowCore({element: element.current, padding}).fn(args);
       }
 
-      return arrowCore({element: element, padding}).fn(args);
+      return arrowCore({element, padding}).fn(args);
     },
   };
 };

--- a/packages/react-dom/src/index.ts
+++ b/packages/react-dom/src/index.ts
@@ -117,7 +117,11 @@ export const arrow = ({
         return arrowCore({element: element.current, padding}).fn(args);
       }
 
-      return arrowCore({element, padding}).fn(args);
+      if (element) {
+        return arrowCore({element, padding}).fn(args);
+      }
+
+      return {};
     },
   };
 };

--- a/packages/react-dom/src/index.ts
+++ b/packages/react-dom/src/index.ts
@@ -1,15 +1,16 @@
 import type {
   ComputePositionConfig,
   ComputePositionReturn,
+  Middleware,
+  SideObject,
   VirtualElement,
 } from '@floating-ui/core';
-import {computePosition} from '@floating-ui/dom';
+import {computePosition, arrow as arrowCore} from '@floating-ui/dom';
 import {useCallback, useMemo, useState, useRef, MutableRefObject} from 'react';
 import useIsomorphicLayoutEffect from 'use-isomorphic-layout-effect';
 import {useLatestRef} from './utils/useLatestRef';
 
 export {
-  arrow,
   autoPlacement,
   flip,
   hide,
@@ -97,3 +98,26 @@ export function useFloating({
     [data, update, setReference, setFloating]
   );
 }
+
+export const arrow = ({
+  element,
+  padding,
+}: {
+  element: MutableRefObject<HTMLElement | null> | HTMLElement;
+  padding: number | SideObject;
+}): Middleware => {
+  function isRef(value: unknown): value is MutableRefObject<unknown> {
+    return Object.prototype.hasOwnProperty.call(value, 'current');
+  }
+
+  return {
+    name: 'arrow',
+    fn(args) {
+      if (isRef(element) && element.current != null) {
+        return arrowCore({element: element.current, padding}).fn(args);
+      }
+
+      return arrowCore({element: element, padding}).fn(args);
+    },
+  };
+};

--- a/packages/react-dom/test/visual/index.html
+++ b/packages/react-dom/test/visual/index.html
@@ -20,6 +20,12 @@
     padding: 15px;
     width: 500px;
   }
+
+  #arrow {
+    width: 15px;
+    height: 15px;
+    background: yellow;
+  }
 </style>
 
 <div id="root"></div>

--- a/packages/react-dom/test/visual/index.js
+++ b/packages/react-dom/test/visual/index.js
@@ -1,11 +1,19 @@
-import {useEffect} from 'react';
+import {useEffect, useRef} from 'react';
 import {render} from 'react-dom';
-import {useFloating, shift, flip, getScrollParents} from '../../src';
+import {useFloating, shift, flip, arrow, getScrollParents} from '../../src';
 
 function App() {
-  const {x, y, reference, floating, update} = useFloating({
+  const arrowRef = useRef();
+  const {
+    x,
+    y,
+    reference,
+    floating,
+    update,
+    middlewareData: {arrow: {x: arrowX, y: arrowY} = {}},
+  } = useFloating({
     placement: 'top-end',
-    middleware: [flip(), shift()],
+    middleware: [flip(), shift(), arrow({element: arrowRef})],
   });
 
   useEffect(() => {
@@ -41,11 +49,20 @@ function App() {
         ref={floating}
         style={{
           position: 'absolute',
-          left: `${x}px`,
-          top: `${y}px`,
+          left: x ?? '',
+          top: y ?? '',
         }}
       >
         Floating
+        <div
+          id="arrow"
+          ref={arrowRef}
+          style={{
+            position: 'absolute',
+            left: arrowX ?? '',
+            top: arrowY ?? '',
+          }}
+        ></div>
       </div>
     </>
   );

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -159,7 +159,11 @@ export const arrow = ({
         return arrowCore({element: element.current, padding}).fn(args);
       }
 
-      return arrowCore({element, padding}).fn(args);
+      if (element) {
+        return arrowCore({element, padding}).fn(args);
+      }
+
+      return {};
     },
   };
 };

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -159,7 +159,7 @@ export const arrow = ({
         return arrowCore({element: element.current, padding}).fn(args);
       }
 
-      return arrowCore({element: element, padding}).fn(args);
+      return arrowCore({element, padding}).fn(args);
     },
   };
 };

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -6,17 +6,17 @@ import {
   useCallback,
   RefObject,
 } from 'react';
-import {computePosition} from '@floating-ui/core';
+import {computePosition, arrow as arrowCore} from '@floating-ui/core';
 import type {
   Placement,
   Middleware,
   ComputePositionReturn,
+  SideObject,
 } from '@floating-ui/core';
 import {createPlatform} from './createPlatform';
 import {useLatestRef} from './utils/useLatestRef';
 
 export {
-  arrow,
   autoPlacement,
   flip,
   hide,
@@ -139,4 +139,27 @@ export const useFloating = ({
     }),
     [data, setReference, setFloating, setOffsetParent, update]
   );
+};
+
+export const arrow = ({
+  element,
+  padding,
+}: {
+  element: any;
+  padding: number | SideObject;
+}): Middleware => {
+  function isRef(value: unknown) {
+    return Object.prototype.hasOwnProperty.call(value, 'current');
+  }
+
+  return {
+    name: 'arrow',
+    fn(args) {
+      if (isRef(element) && element.current != null) {
+        return arrowCore({element: element.current, padding}).fn(args);
+      }
+
+      return arrowCore({element: element, padding}).fn(args);
+    },
+  };
 };


### PR DESCRIPTION
Closes #20

Users can now do the following:

```js
function App() {
  const arrowRef = useRef();
  useFloating({
    middleware: [arrow({element: arrowRef})]
  });
}
```