### PR TITLE
fix: react stale position after middleware change

### DIFF
--- a/packages/react-dom/src/index.ts
+++ b/packages/react-dom/src/index.ts
@@ -54,6 +54,8 @@ export function useFloating({
     middlewareData: {},
   });
 
+  const skipRenderRef = useRef<boolean>(false);
+
   // Memoize middleware internally, to remove the requirement of memoization by consumer
   const latestMiddleware = useLatestRef(middleware);
 
@@ -62,6 +64,13 @@ export function useFloating({
       return;
     }
 
+    if (skipRenderRef.current) {
+      skipRenderRef.current = false;
+      return;
+    }
+
+    skipRenderRef.current = true;
+
     computePosition(reference.current, floating.current, {
       middleware: latestMiddleware.current,
       placement,
@@ -69,7 +78,7 @@ export function useFloating({
     }).then(setData);
   }, [latestMiddleware, placement, strategy]);
 
-  useIsomorphicLayoutEffect(update, [update]);
+  useIsomorphicLayoutEffect(update);
 
   const setReference = useCallback(
     (node) => {

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -107,7 +107,7 @@ export const useFloating = ({
 
   useLayoutEffect(() => {
     requestAnimationFrame(update);
-  }, [update]);
+  });
 
   const setReference = useCallback(
     (node) => {

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -81,6 +81,8 @@ export const useFloating = ({
     [offsetParent, scrollOffsets, sameScrollView]
   );
 
+  const skipRenderRef = useRef<boolean>(false);
+
   // Memoize middleware internally, to remove the requirement of memoization by consumer
   const latestMiddleware = useLatestRef(middleware);
 
@@ -88,6 +90,13 @@ export const useFloating = ({
     if (!reference.current || !floating.current) {
       return;
     }
+
+    if (skipRenderRef.current) {
+      skipRenderRef.current = false;
+      return;
+    }
+
+    skipRenderRef.current = true;
 
     computePosition(reference.current, floating.current, {
       middleware: latestMiddleware.current,


### PR DESCRIPTION
Uses a `skip` ref to simply break the infinite render loop, position always updates on a render. Floating UI's core actually uses this type of technique as well whenever `reset` is returned

Closes #27