### PR TITLE
Revert "fix: react stale position after middleware change"

### DIFF
--- a/packages/react-dom/src/index.ts
+++ b/packages/react-dom/src/index.ts
@@ -54,8 +54,6 @@ export function useFloating({
     middlewareData: {},
   });
 
-  const skipRenderRef = useRef<boolean>(false);
-
   // Memoize middleware internally, to remove the requirement of memoization by consumer
   const latestMiddleware = useLatestRef(middleware);
 
@@ -64,13 +62,6 @@ export function useFloating({
       return;
     }
 
-    if (skipRenderRef.current) {
-      skipRenderRef.current = false;
-      return;
-    }
-
-    skipRenderRef.current = true;
-
     computePosition(reference.current, floating.current, {
       middleware: latestMiddleware.current,
       placement,
@@ -78,7 +69,7 @@ export function useFloating({
     }).then(setData);
   }, [latestMiddleware, placement, strategy]);
 
-  useIsomorphicLayoutEffect(update);
+  useIsomorphicLayoutEffect(update, [update]);
 
   const setReference = useCallback(
     (node) => {

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -81,8 +81,6 @@ export const useFloating = ({
     [offsetParent, scrollOffsets, sameScrollView]
   );
 
-  const skipRenderRef = useRef<boolean>(false);
-
   // Memoize middleware internally, to remove the requirement of memoization by consumer
   const latestMiddleware = useLatestRef(middleware);
 
@@ -90,13 +88,6 @@ export const useFloating = ({
     if (!reference.current || !floating.current) {
       return;
     }
-
-    if (skipRenderRef.current) {
-      skipRenderRef.current = false;
-      return;
-    }
-
-    skipRenderRef.current = true;
 
     computePosition(reference.current, floating.current, {
       middleware: latestMiddleware.current,
@@ -107,7 +98,7 @@ export const useFloating = ({
 
   useLayoutEffect(() => {
     requestAnimationFrame(update);
-  });
+  }, [update]);
 
   const setReference = useCallback(
     (node) => {


### PR DESCRIPTION
Reverts atomiks/floating-ui#33

So as magical as this seemed as a solution it neds up causing an infinite loop if you try to use `size()` middleware 🙄 

For now, I am going to document the need to run `update` if `middleware` changes yourself, but, I think @KubaJastrz's idea of passing in new middleware to the `update()` function is solid, we can explore that as a solution. 